### PR TITLE
圆形指示器时添加指示器距banner底部间距

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 |indicator_margin| dimension|指示器之间的间距
 |indicator_drawable_selected| reference|指示器选中效果
 |indicator_drawable_unselected| reference|指示器未选中效果
+|circle_indicator_margin_bottom| dimension|CIRCLE_INDICATOR时有效，指示器与banner底部间距
 |image_scale_type| enum |和imageview的ScaleType作用一样
 
 

--- a/banner/src/main/java/com/youth/banner/Banner.java
+++ b/banner/src/main/java/com/youth/banner/Banner.java
@@ -98,7 +98,7 @@ public class Banner extends FrameLayout implements OnPageChangeListener {
         mIndicatorWidth = typedArray.getDimensionPixelSize(R.styleable.Banner_indicator_width, indicatorSize);
         mIndicatorHeight = typedArray.getDimensionPixelSize(R.styleable.Banner_indicator_height, indicatorSize);
         mIndicatorMargin = typedArray.getDimensionPixelSize(R.styleable.Banner_indicator_margin, BannerConfig.PADDING_SIZE);
-        mCircleIndicatorMarginBottom = typedArray.getDimensionPixelSize(R.styleable.Banner_circle_indicator_margin_bottom, BannerConfig.PADDING_SIZE);
+        mCircleIndicatorMarginBottom = typedArray.getDimensionPixelSize(R.styleable.Banner_circle_indicator_margin_bottom, BannerConfig.CIRCLE_INDICATOR_MARGIN_BOTTOM);
         mIndicatorSelectedResId = typedArray.getResourceId(R.styleable.Banner_indicator_drawable_selected, R.drawable.gray_radius);
         mIndicatorUnselectedResId = typedArray.getResourceId(R.styleable.Banner_indicator_drawable_unselected, R.drawable.white_radius);
         scaleType = typedArray.getInt(R.styleable.Banner_image_scale_type, scaleType);

--- a/banner/src/main/java/com/youth/banner/Banner.java
+++ b/banner/src/main/java/com/youth/banner/Banner.java
@@ -36,6 +36,7 @@ public class Banner extends FrameLayout implements OnPageChangeListener {
     private int mIndicatorMargin = BannerConfig.PADDING_SIZE;
     private int mIndicatorWidth;
     private int mIndicatorHeight;
+    private int mCircleIndicatorMarginBottom;
     private int indicatorSize;
     private int bannerStyle = BannerConfig.CIRCLE_INDICATOR;
     private int delayTime = BannerConfig.TIME;
@@ -97,6 +98,7 @@ public class Banner extends FrameLayout implements OnPageChangeListener {
         mIndicatorWidth = typedArray.getDimensionPixelSize(R.styleable.Banner_indicator_width, indicatorSize);
         mIndicatorHeight = typedArray.getDimensionPixelSize(R.styleable.Banner_indicator_height, indicatorSize);
         mIndicatorMargin = typedArray.getDimensionPixelSize(R.styleable.Banner_indicator_margin, BannerConfig.PADDING_SIZE);
+        mCircleIndicatorMarginBottom = typedArray.getDimensionPixelSize(R.styleable.Banner_circle_indicator_margin_bottom, BannerConfig.PADDING_SIZE);
         mIndicatorSelectedResId = typedArray.getResourceId(R.styleable.Banner_indicator_drawable_selected, R.drawable.gray_radius);
         mIndicatorUnselectedResId = typedArray.getResourceId(R.styleable.Banner_indicator_drawable_unselected, R.drawable.white_radius);
         scaleType = typedArray.getInt(R.styleable.Banner_image_scale_type, scaleType);
@@ -164,6 +166,18 @@ public class Banner extends FrameLayout implements OnPageChangeListener {
                 break;
         }
         return this;
+    }
+
+    public void setCircleIndicatorMarginBottom(int marginBottom){
+        mCircleIndicatorMarginBottom = marginBottom;
+        if (bannerStyle == BannerConfig.CIRCLE_INDICATOR && mCircleIndicatorMarginBottom > 0) {
+            RelativeLayout.LayoutParams params2 = (RelativeLayout.LayoutParams) indicator.getLayoutParams();
+            params2.bottomMargin = mCircleIndicatorMarginBottom;
+        }
+    }
+
+    public int getCircleIndicatorMarginBottom(){
+        return mCircleIndicatorMarginBottom;
     }
 
     public Banner setBannerAnimation(Class<? extends PageTransformer> transformer) {
@@ -409,6 +423,11 @@ public class Banner extends FrameLayout implements OnPageChangeListener {
                 indicator.addView(imageView, params);
             else if (bannerStyle == BannerConfig.CIRCLE_INDICATOR_TITLE_INSIDE)
                 indicatorInside.addView(imageView, params);
+
+            if (bannerStyle == BannerConfig.CIRCLE_INDICATOR && mCircleIndicatorMarginBottom > 0) {
+                RelativeLayout.LayoutParams params2 = (RelativeLayout.LayoutParams) indicator.getLayoutParams();
+                params2.bottomMargin = mCircleIndicatorMarginBottom;
+            }
         }
     }
 

--- a/banner/src/main/java/com/youth/banner/BannerConfig.java
+++ b/banner/src/main/java/com/youth/banner/BannerConfig.java
@@ -22,6 +22,7 @@ public class BannerConfig {
      * banner
      */
     public static final int PADDING_SIZE=5;
+    public static final int CIRCLE_INDICATOR_MARGIN_BOTTOM=0;
     public static final int TIME=2000;
     public static final int DURATION=800;
     public static final boolean IS_AUTO_PLAY=true;

--- a/banner/src/main/res/values/attr.xml
+++ b/banner/src/main/res/values/attr.xml
@@ -11,6 +11,7 @@
         <attr name="indicator_width" format="dimension" />
         <attr name="indicator_height" format="dimension" />
         <attr name="indicator_margin" format="dimension" />
+        <attr name="circle_indicator_margin_bottom" format="dimension" />
         <attr name="indicator_drawable_selected" format="reference" />
         <attr name="indicator_drawable_unselected" format="reference" />
         <attr name="image_scale_type" format="enum">


### PR DESCRIPTION
当用这个做全屏的引导页时，可能底部需要放置登录/注册的按钮，那么圆形指示器的位置可能需要自己定义。添加了一个`circle_indicator_margin_bottom`属性来表示指示器距banner底部的间距