### PR TITLE
Update Banner.java

### DIFF
--- a/banner/src/main/java/com/youth/banner/Banner.java
+++ b/banner/src/main/java/com/youth/banner/Banner.java
@@ -491,7 +491,10 @@ public class Banner extends FrameLayout implements OnPageChangeListener {
      * @return 下标从0开始
      */
     public int toRealPosition(int position) {
-        int realPosition = (position - 1) % count;
+        int realPosition;
+        if(count!=0){
+            realPosition = (position - 1) % count;
+        }
         if (realPosition < 0)
             realPosition += count;
         return realPosition;


### PR DESCRIPTION
#52 java.lang.ArithmeticException
divide by zero
com.youth.banner.Banner.d(Banner.java:487)
发生次数
1
影响用户数
1
状态变更
解决方案
该异常表示进行算术运算时除零。
[解决方案]：这种异常说明使用了零值做分母，多由于程序员疏忽导致，或者出现在使用第三方控件时未做判断，建议在所有除法运算前检查分母是否为零。

三星手机会报错，count为0，取余的时候没判断是否count为0