### PR TITLE
banner.update 无效的bug

### DIFF
--- a/banner/src/main/java/com/youth/banner/Banner.java
+++ b/banner/src/main/java/com/youth/banner/Banner.java
@@ -233,7 +233,7 @@ public class Banner extends FrameLayout implements OnPageChangeListener {
     }
 
     public Banner setImages(List<?> imageUrls) {
-        this.imageUrls = imageUrls;
+        this.imageUrls.addAll(imageUrls);
         this.count = imageUrls.size();
         return this;
     }


### PR DESCRIPTION
banner.setImages中this.imageUrls = imageUrls 导致引用外部list，update的时候会把外部list清空，导致最终this.imageUrls和外部list都为空