### PR TITLE
修复一个小bug

### DIFF
--- a/banner/src/main/java/com/youth/banner/Banner.java
+++ b/banner/src/main/java/com/youth/banner/Banner.java
@@ -245,7 +245,7 @@ public class Banner<T, BA extends BannerAdapter> extends FrameLayout {
                 int count = banner.getItemCount();
                 if (count <= 1) return;
                 int next = banner.getCurrentItem() % (count - 1) + 1;
-                if (next == 1) {
+                if (banner.getCurrentItem() == count - 1) {
                     banner.setCurrentItem(next, false);
                     banner.post(banner.mLoopTask);
                 } else {


### PR DESCRIPTION
修复当banner从第一个item直接移动到最后一个item后，再次自动切换时，直接跳到第二个item.